### PR TITLE
feat: GCP環境のセットアップ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use Python 3.9 slim image
+FROM python:3.9-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Set environment variables
+ENV PORT=8080
+
+# Expose port
+EXPOSE 8080
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: build deploy run-local test clean
+
+# 環境変数
+PROJECT_ID := $(shell gcloud config get-value project)
+REGION := asia-northeast1
+SERVICE_NAME := webhook-service
+
+# ローカル開発
+run-local:
+	uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
+
+# テスト実行
+test:
+	pytest
+
+# Dockerイメージのビルド
+build:
+	docker build -t gcr.io/$(PROJECT_ID)/$(SERVICE_NAME) .
+
+# Cloud Runへのデプロイ
+deploy: build
+	docker push gcr.io/$(PROJECT_ID)/$(SERVICE_NAME)
+	gcloud run deploy $(SERVICE_NAME) \
+		--image gcr.io/$(PROJECT_ID)/$(SERVICE_NAME) \
+		--platform managed \
+		--region $(REGION) \
+		--allow-unauthenticated
+
+# Cloud Buildを使用したデプロイ
+deploy-cloudbuild:
+	gcloud builds submit --config cloudbuild.yaml
+
+# ローカルのDockerコンテナを実行（テスト用）
+run-docker: build
+	docker run -p 8080:8080 gcr.io/$(PROJECT_ID)/$(SERVICE_NAME)
+
+# クリーンアップ
+clean:
+	find . -type d -name "__pycache__" -exec rm -r {} +
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name "*.pyo" -delete
+	find . -type f -name "*.pyd" -delete
+	find . -type f -name ".coverage" -delete
+	find . -type d -name "*.egg-info" -exec rm -r {} +
+	find . -type d -name "*.egg" -exec rm -r {} +
+	find . -type d -name ".pytest_cache" -exec rm -r {} +
+	find . -type d -name ".coverage" -exec rm -r {} +

--- a/README.md
+++ b/README.md
@@ -60,7 +60,27 @@ cp .env.example .env
 
 ### デプロイ
 
-Google Cloud Runへのデプロイ手順は後日追加予定です。
+Google Cloud Runへのデプロイ手順は[GCP環境構築手順](docs/gcp-setup.md)を参照してください。
+
+### 利用可能なコマンド
+
+プロジェクトルートにある`Makefile`を使用して、以下のコマンドを実行できます：
+
+```bash
+# ローカル開発
+make run-local    # 開発サーバーを起動（ホットリロード有効）
+make test         # テストを実行
+make clean        # キャッシュファイルなどをクリーンアップ
+
+# Docker操作
+make run-docker   # Dockerコンテナをローカルで実行（テスト用）
+
+# デプロイ
+make deploy           # Cloud Runへデプロイ（Docker使用）
+make deploy-cloudbuild # Cloud Buildを使用してデプロイ
+```
+
+詳細な使用方法は[GCP環境構築手順](docs/gcp-setup.md)を参照してください。
 
 ## 開発ガイドライン
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,26 @@
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/webhook-service', '.']
+  
+  # Push the container image to Container Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/webhook-service']
+  
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+    - 'run'
+    - 'deploy'
+    - 'webhook-service'
+    - '--image'
+    - 'gcr.io/$PROJECT_ID/webhook-service'
+    - '--region'
+    - 'asia-northeast1'
+    - '--platform'
+    - 'managed'
+    - '--allow-unauthenticated'
+
+images:
+  - 'gcr.io/$PROJECT_ID/webhook-service'

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -8,7 +8,7 @@
 - Google Cloud CLIがインストールされていること
 - プロジェクトのローカル開発環境が整っていること
 
-## 1. GCPプロジェクトの作成
+## 1. GCPプロジェクトの作成と請求先設定
 
 1. Google Cloud Consoleにアクセスし、新しいプロジェクトを作成します：
 
@@ -19,6 +19,15 @@ gcloud projects create save-liked-post-notion --name="Save Liked Post in Notion"
 # プロジェクトの設定
 gcloud config set project save-liked-post-notion
 ```
+
+2. 請求先アカウントの設定：
+
+- [Google Cloud Console](https://console.cloud.google.com/billing)にアクセス
+- 「請求先アカウントをリンク」をクリック
+- 既存の請求先アカウントを選択するか、新しい請求先アカウントを作成
+- プロジェクトと請求先アカウントをリンク
+
+注意：GCPの一部のサービスは有料です。料金の詳細は[Google Cloud の料金](https://cloud.google.com/pricing)を参照してください。新規アカウントには無料枠があり、多くの場合、開発やテスト目的での使用であれば無料枠内で収まります。
 
 ## 2. 必要なAPIの有効化
 

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -56,6 +56,36 @@ gcloud projects add-iam-policy-binding save-liked-post-notion \
 
 ## 4. ローカル開発環境からのデプロイ
 
+プロジェクトルートにある`Makefile`を使用して、以下のコマンドでビルドとデプロイを実行できます：
+
+```bash
+# ローカルで開発サーバーを起動
+make run-local
+
+# テストを実行
+make test
+
+# Dockerイメージをビルドしてローカルで実行（テスト用）
+make run-docker
+
+# Cloud Runへデプロイ（Dockerを使用）
+make deploy
+
+# Cloud Buildを使用してデプロイ
+make deploy-cloudbuild
+
+# キャッシュファイルなどをクリーンアップ
+make clean
+```
+
+各コマンドの詳細：
+- `run-local`: FastAPIの開発サーバーをローカルで起動
+- `test`: pytestを使用してテストを実行
+- `run-docker`: ビルドしたDockerイメージをローカルで実行（動作確認用）
+- `deploy`: Dockerイメージをビルドし、Cloud Runにデプロイ
+- `deploy-cloudbuild`: Cloud Buildを使用してビルドとデプロイを実行
+- `clean`: 一時ファイルやキャッシュを削除
+
 1. アプリケーションのビルドとデプロイ：
 
 ```bash

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -1,0 +1,91 @@
+# Google Cloud Platform環境構築手順
+
+このドキュメントでは、Save Liked Post in NotionプロジェクトのGoogle Cloud Platform（GCP）環境構築手順について説明します。
+
+## 前提条件
+
+- Google Cloudアカウントを持っていること
+- Google Cloud CLIがインストールされていること
+- プロジェクトのローカル開発環境が整っていること
+
+## 1. GCPプロジェクトの作成
+
+1. Google Cloud Consoleにアクセスし、新しいプロジェクトを作成します：
+
+```bash
+# プロジェクトの作成
+gcloud projects create save-liked-post-notion --name="Save Liked Post in Notion"
+
+# プロジェクトの設定
+gcloud config set project save-liked-post-notion
+```
+
+## 2. 必要なAPIの有効化
+
+以下のAPIを有効化します：
+
+```bash
+# Cloud Run APIの有効化
+gcloud services enable run.googleapis.com
+
+# Cloud Build APIの有効化（コンテナのビルドに必要）
+gcloud services enable cloudbuild.googleapis.com
+```
+
+## 3. サービスアカウントの作成と設定
+
+```bash
+# サービスアカウントの作成
+gcloud iam service-accounts create webhook-service \
+    --display-name="Webhook Service Account"
+
+# 必要な権限の付与
+gcloud projects add-iam-policy-binding save-liked-post-notion \
+    --member="serviceAccount:webhook-service@save-liked-post-notion.iam.gserviceaccount.com" \
+    --role="roles/run.invoker"
+```
+
+## 4. ローカル開発環境からのデプロイ
+
+1. アプリケーションのビルドとデプロイ：
+
+```bash
+# Cloud Runへのデプロイ
+gcloud run deploy webhook-service \
+    --source . \
+    --region asia-northeast1 \
+    --platform managed \
+    --allow-unauthenticated \
+    --service-account webhook-service@save-liked-post-notion.iam.gserviceaccount.com
+```
+
+## 5. セキュリティ設定
+
+### 認証設定
+
+- Cloud RunのサービスはデフォルトでIAM認証が必要です
+- このプロジェクトではIFTTTからのWebhookを受け取るため、`--allow-unauthenticated`フラグを使用しています
+- 追加のセキュリティ層として、Webhookエンドポイントで独自の認証トークンを実装することを推奨します
+
+### 環境変数の設定
+
+機密情報は環境変数として設定します：
+
+```bash
+gcloud run services update webhook-service \
+    --set-env-vars="NOTION_API_KEY=your_notion_api_key" \
+    --set-env-vars="WEBHOOK_SECRET=your_webhook_secret"
+```
+
+## 6. 動作確認
+
+デプロイ後のエンドポイントURLは以下のコマンドで確認できます：
+
+```bash
+gcloud run services describe webhook-service \
+    --platform managed \
+    --region asia-northeast1 \
+    --format='value(status.url)'
+```
+
+このURLをIFTTTのWebhookアクションで使用します。


### PR DESCRIPTION
Closes #11

# 変更内容
- GCP環境構築手順のドキュメント（docs/gcp-setup.md）を追加
- Dockerfileの作成
- Cloud Build設定ファイル（cloudbuild.yaml）の作成

# 主な設定内容
- Cloud Runを使用してWebhookサービスをホスティング
- 必要なAPIの有効化手順
- セキュリティ設定（サービスアカウント、認証）
- デプロイ手順

# 確認項目
- [x] ドキュメントの内容が正確か
- [x] Dockerfileの設定が適切か
- [x] Cloud Build設定が正しいか