### PR TITLE
feat: implement webhook request parsing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,27 @@
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from datetime import datetime
 import os
+import uuid
 
 app = FastAPI(title="Save Liked Post in Notion")
 
-class Tweet(BaseModel):
-    text: str
-    username: str
-    tweet_url: str
-    created_at: str
-    embed_code: str
+class TweetRequest(BaseModel):
+    text: str = Field(..., description="The text content of the tweet")
+    userName: str = Field(..., description="The username of the tweet author")
+    linkToTweet: str = Field(..., description="URL to the original tweet")
+    createdAt: str = Field(..., description="Creation timestamp of the tweet in ISO format")
+    tweetEmbedCode: str = Field(..., description="HTML embed code for the tweet")
+
+    def validate_date_format(self):
+        try:
+            datetime.fromisoformat(self.createdAt.replace('Z', '+00:00'))
+            return True
+        except ValueError:
+            return False
+
+class TweetResponse(BaseModel):
+    id: str
 
 @app.get("/")
 async def root():
@@ -19,9 +31,17 @@ async def root():
 async def webhook_get():
     return {"message": "Hello World"}
 
-@app.post("/webhook")
-async def webhook_post():
-    return {"message": "Hello World"}
+@app.post("/webhook", response_model=TweetResponse)
+async def webhook_post(tweet: TweetRequest):
+    if not tweet.validate_date_format():
+        raise HTTPException(status_code=422, detail="Invalid date format. Expected ISO format.")
+    
+    # Generate a unique ID for the tweet
+    tweet_id = str(uuid.uuid4())
+    
+    # TODO: Save the tweet data to storage
+    
+    return TweetResponse(id=tweet_id)
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -9,6 +9,47 @@ def test_hello_world_get():
     assert response.json() == {"message": "Hello World"}
 
 def test_hello_world_post():
-    response = client.post("/webhook")
+    tweet_data = {
+        "text": "This is a test tweet",
+        "userName": "testuser",
+        "linkToTweet": "https://twitter.com/testuser/status/123456789",
+        "createdAt": "2025-02-10T13:35:49Z",
+        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+    }
+    response = client.post("/webhook", json=tweet_data)
     assert response.status_code == 200
-    assert response.json() == {"message": "Hello World"}
+    assert "id" in response.json()
+
+def test_webhook_post_success():
+    tweet_data = {
+        "text": "This is a test tweet",
+        "userName": "testuser",
+        "linkToTweet": "https://twitter.com/testuser/status/123456789",
+        "createdAt": "2025-02-10T13:35:49Z",
+        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+    }
+    response = client.post("/webhook", json=tweet_data)
+    assert response.status_code == 200
+    assert "id" in response.json()
+
+def test_webhook_post_missing_required_fields():
+    tweet_data = {
+        "text": "This is a test tweet",
+        # userName is missing
+        "linkToTweet": "https://twitter.com/testuser/status/123456789",
+        "createdAt": "2025-02-10T13:35:49Z",
+        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+    }
+    response = client.post("/webhook", json=tweet_data)
+    assert response.status_code == 422
+
+def test_webhook_post_invalid_date_format():
+    tweet_data = {
+        "text": "This is a test tweet",
+        "userName": "testuser",
+        "linkToTweet": "https://twitter.com/testuser/status/123456789",
+        "createdAt": "invalid-date",  # Invalid date format
+        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+    }
+    response = client.post("/webhook", json=tweet_data)
+    assert response.status_code == 422


### PR DESCRIPTION
Closes #13

## 変更内容
- webhookエンドポイントでリクエストボディのパースを実装
- 以下のパラメータに対応：
  - text
  - userName
  - linkToTweet
  - createdAt
  - tweetEmbedCode
- バリデーション機能を追加：
  - 必須フィールドのチェック
  - 日付フォーマットの検証
- エラー時は422エラーを返却
- テストケースの追加と更新

## 動作確認
- テストケースを追加し、以下のシナリオを確認：
  - 正常系：すべてのパラメータが正しい場合
  - 異常系：必須フィールドが欠落している場合
  - 異常系：日付フォーマットが不正な場合