### PR TITLE
feat: webhookにAPI Key認証を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 NOTION_API_KEY=your_notion_api_key
 NOTION_DATABASE_ID=your_notion_database_id
 
+# Webhook設定
+WEBHOOK_API_KEY=your_webhook_api_key
+
 # アプリケーション設定
 APP_ENV=development
 PORT=8000

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deploy: test
 			--platform managed \
 			--allow-unauthenticated \
 			--service-account webhook-service@save-liked-post-notion.iam.gserviceaccount.com \
-			--set-env-vars NOTION_API_KEY=$(NOTION_API_KEY),NOTION_DATABASE_ID=$(NOTION_DATABASE_ID); \
+			--set-env-vars NOTION_API_KEY=$(NOTION_API_KEY),NOTION_DATABASE_ID=$(NOTION_DATABASE_ID),WEBHOOK_API_KEY=$(WEBHOOK_API_KEY); \
 	else \
 		echo "Tests failed. Deployment aborted."; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,59 @@ make deploy       # Cloud Runへデプロイ
 
 詳細な使用方法は[GCP環境構築手順](docs/gcp-setup.md)を参照してください。
 
+## デプロイ後の使用方法
+
+### 1. 環境変数の設定
+
+デプロイ環境で以下の環境変数を設定してください：
+
+```bash
+NOTION_API_KEY=your_notion_api_key
+NOTION_DATABASE_ID=your_database_id
+WEBHOOK_API_KEY=your_webhook_api_key  # Webhookの認証に使用
+```
+
+### 2. WebhookエンドポイントへのPOSTリクエスト
+
+以下のフォーマットでPOSTリクエストを送信します：
+
+```bash
+curl -X POST https://your-deployed-url/webhook \
+  -H "Content-Type: text/plain" \
+  -H "X-API-Key: your_webhook_api_key" \
+  -d "ツイートのテキスト___POST_FIELD_SEPARATOR___ユーザー名___POST_FIELD_SEPARATOR___https://twitter.com/user/status/123___POST_FIELD_SEPARATOR___2025-02-11T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>埋め込みコード</blockquote>"
+```
+
+リクエストボディは以下の5つのフィールドを`___POST_FIELD_SEPARATOR___`で区切って送信します：
+
+1. text: ツイートのテキスト（必須）
+2. userName: ユーザー名
+3. linkToTweet: ツイートへのリンク
+4. createdAt: 作成日時（ISO形式または "Month DD, YYYY at HH:MMAM/PM" 形式）
+5. tweetEmbedCode: 埋め込みコード
+
+### 3. レスポンス
+
+成功時のレスポンス（200 OK）：
+```json
+{
+  "pageId": "created-notion-page-id",
+  "url": "https://notion.so/page-url"
+}
+```
+
+エラー時のレスポンス（401/422）：
+```json
+{
+  "message": "エラーメッセージ",
+  "details": {}
+}
+```
+
+主なエラーケース：
+- 401: API Keyが未指定または無効
+- 422: リクエストボディのフォーマットが不正、必須フィールドが空
+
 ## 開発ガイドライン
 
 ### テスト

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request, Security, Depends
+from fastapi import FastAPI, HTTPException, Request, Security, Depends, Header
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, Field, ValidationError
@@ -37,28 +37,22 @@ app = FastAPI(
 
 # API Key認証の設定
 API_KEY_NAME = "X-API-Key"
-api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
 
-async def get_api_key(api_key_header: str = Security(api_key_header)):
-    if api_key_header is None:
+def get_api_key(api_key: str = Header(None, alias="X-API-Key")) -> str:
+    """API Keyを取得する関数"""
+    if api_key is None:
         raise HTTPException(
             status_code=401,
-            detail={
-                "message": "API key is missing",
-                "details": {}
-            }
+            detail={"message": "Invalid API Key"}
         )
-
-    if api_key_header != os.getenv("WEBHOOK_API_KEY"):
+    
+    if api_key != os.getenv("WEBHOOK_API_KEY"):
         raise HTTPException(
             status_code=401,
-            detail={
-                "message": "Invalid API key",
-                "details": {}
-            }
+            detail={"message": "Invalid API Key"}
         )
-
-    return api_key_header
+    
+    return api_key
 
 # ミドルウェアを追加
 app.add_middleware(ServerErrorMiddleware, handler=general_exception_handler)
@@ -80,7 +74,7 @@ async def hello_world(api_key: str = Depends(get_api_key)):
     return {"message": "Hello World"}
 
 @app.post("/webhook", response_model=NotionPageResponse)
-async def webhook_post(tweet: Tweet, api_key: str = Depends(get_api_key)):
+async def webhook_post(request: Request, api_key: str = Depends(get_api_key)):
     """Webhookエンドポイント
     
     リクエストボディは以下の順序でフィールドを___POST_FIELD_SEPARATOR___で区切って送信:
@@ -90,91 +84,55 @@ async def webhook_post(tweet: Tweet, api_key: str = Depends(get_api_key)):
     4. createdAt: 作成日時（ISO形式または "Month DD, YYYY at HH:MMAM/PM" 形式）
     5. tweetEmbedCode: 埋め込みコード
     """
-    # リクエストボディを取得
+    # リクエストボディをテキストとして読み取る
     body = await request.body()
-    body_str = body.decode()
+    raw_text = body.decode()
     
-    # デバッグ用ログ
-    logging.info(f"Received webhook request body: {body_str}")
-    
-    try:
-        # 区切り文字で分割してフィールドを取得
-        fields = body_str.split('___POST_FIELD_SEPARATOR___')
-        logging.info(f"Split fields count: {len(fields)}")
-        
-        if len(fields) != 5:
-            error_msg = f"Invalid number of fields in request body: expected 5, got {len(fields)}"
-            logging.warning(error_msg)
-            raise ValidationException(error_msg)
-            
-        # createdAtフィールドの日付フォーマットを変換
-        created_at = fields[3]
-        try:
-            # "Month DD, YYYY at HH:MMAM/PM" 形式の場合、ISO形式に変換
-            if "at" in created_at:
-                from datetime import datetime
-                dt = datetime.strptime(created_at, "%B %d, %Y at %I:%M%p")
-                created_at = dt.isoformat()
-        except ValueError as e:
-            logging.warning(f"Failed to parse date: {created_at}")
-            # 変換に失敗した場合は、そのままの値を使用（Pydanticのバリデーションで処理）
-            pass
-            
-        # 順序に従ってデータを構築
-        data = {
-            "text": fields[0].strip(),
-            "userName": fields[1].strip(),
-            "linkToTweet": fields[2].strip(),
-            "createdAt": created_at.strip(),
-            "tweetEmbedCode": fields[4].strip()
-        }
-        
-        # 必須フィールドの空文字チェック
-        required_fields = ["text", "userName", "linkToTweet", "createdAt"]
-        empty_fields = [field for field in required_fields if not data[field]]
-        if empty_fields:
-            error_msg = f"Required fields cannot be empty: {', '.join(empty_fields)}"
-            logging.warning(error_msg)
-            raise ValidationException(error_msg)
-            
-        # Tweetモデルとしてバリデーション
-        try:
-            tweet = Tweet(**data)
-        except ValidationError as e:
-            # バリデーションエラーの詳細を確認
-            for error in e.errors():
-                if error.get("type") == "datetime_from_date_parsing":
-                    return JSONResponse(
-                        status_code=422,
-                        content={
-                            "message": "Invalid date format. Expected ISO format.",
-                            "details": {}
-                        }
-                    )
-            raise ValidationException(f"Invalid Tweet data: {str(e)}")
-        
-        # Notionページの作成
-        page = notion_service.create_page({
-            "text": tweet.text,
-            "userName": tweet.userName,
-            "linkToTweet": tweet.linkToTweet,
-            "createdAt": tweet.createdAt.isoformat(),
-        })
-
-        # ツイートの埋め込みコードを追加
-        notion_service.add_tweet_embed_code(page["id"], tweet.tweetEmbedCode)
-
-        return NotionPageResponse(id=page["id"])
-    except ValidationException as e:
-        return JSONResponse(
-            status_code=422,
-            content={
-                "message": str(e),
-                "details": {}
-            }
+    # フィールドを分割
+    fields = raw_text.split("___POST_FIELD_SEPARATOR___")
+    if len(fields) != 5:
+        raise ValidationException(
+            "Invalid request format. Expected 5 fields separated by ___POST_FIELD_SEPARATOR___",
+            details={"received_fields": len(fields)}
         )
-    except Exception as e:
-        raise AppException("Failed to create Notion page", 500, {"error": str(e)})
+    
+    # フィールドを取り出す
+    text, user_name, link_to_tweet, created_at, tweet_embed_code = fields
+
+    # 必須フィールドのバリデーション
+    if not text:
+        raise ValidationException(
+            "Text field cannot be empty",
+            details={}
+        )
+
+    # 日付フォーマットを検証して変換
+    try:
+        # まずISO形式として解析を試みる
+        parsed_date = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+    except ValueError:
+        try:
+            # 次にMonth DD, YYYY at HH:MMAM/PM形式として解析を試みる
+            parsed_date = datetime.strptime(created_at, "%B %d, %Y at %I:%M%p")
+        except ValueError:
+            raise ValidationException(
+                "Invalid date format. Expected ISO format.",
+                details={}
+            )
+    
+    # Tweetモデルを作成
+    tweet = Tweet(
+        text=text,
+        userName=user_name,
+        linkToTweet=link_to_tweet,
+        createdAt=parsed_date.isoformat(),
+        tweetEmbedCode=tweet_embed_code
+    )
+    
+    # Notionにページを作成
+    page = notion_service.create_page(tweet)
+    
+    return NotionPageResponse(id=page["id"])
 
 # Notionのルーターを追加
 app.include_router(notion.router, prefix="/api/v1/notion", tags=["notion"])

--- a/app/main.py
+++ b/app/main.py
@@ -146,7 +146,7 @@ async def webhook_post(request: Request, api_key: str = Depends(get_api_key)):
         notion_service.add_tweet_embed_code(page["id"], tweet_embed_code)
 
     # レスポンスを返す
-    return NotionPageResponse(pageId=page["id"])
+    return NotionPageResponse(id=page["id"])
 
 # Notionのルーターを追加
 app.include_router(notion.router, prefix="/api/v1/notion", tags=["notion"])

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,9 @@ import json
 import logging
 from fastapi.security.api_key import APIKeyHeader
 
+# ロガーの設定
+logger = logging.getLogger(__name__)
+
 # 環境変数を読み込む
 load_dotenv()
 

--- a/app/main.py
+++ b/app/main.py
@@ -129,9 +129,10 @@ async def webhook_post(request: Request, api_key: str = Depends(get_api_key)):
         tweetEmbedCode=tweet_embed_code
     )
     
-    # Notionにページを作成
-    page = notion_service.create_page(tweet)
-    
+    # NotionServiceを初期化してページを作成
+    logger.info("Creating new Notion page")
+    page = await notion_service.create_page(tweet.dict())  # Pydanticモデルを辞書に変換
+
     return NotionPageResponse(id=page["id"])
 
 # Notionのルーターを追加

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -1,22 +1,22 @@
 import os
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from notion_client import Client
 from notion_client.errors import APIResponseError
 from ..exceptions import NotionAPIException, ValidationException, ConfigurationException
 from ..logging_config import logger
 
 class NotionService:
-    def __init__(self):
-        api_key = os.getenv("NOTION_API_KEY")
-        self.database_id = os.getenv("NOTION_DATABASE_ID")
+    def __init__(self, api_key: Optional[str] = None, database_id: Optional[str] = None):
+        self.api_key = api_key or os.getenv("NOTION_API_KEY")
+        self.database_id = database_id or os.getenv("NOTION_DATABASE_ID")
         
-        if not api_key:
+        if not self.api_key:
             raise ConfigurationException("NOTION_API_KEY is not set")
         if not self.database_id:
             raise ConfigurationException("NOTION_DATABASE_ID is not set")
         
         try:
-            self.notion = Client(auth=api_key)
+            self.notion = Client(auth=self.api_key)
             logger.info("NotionService initialized successfully")
         except Exception as e:
             logger.error("Failed to initialize NotionService", exc_info=True)

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -74,7 +74,7 @@ class NotionService:
             },
             "Tweeted_at": {
                 "date": {
-                    "start": data["createdAt"]
+                    "start": data["createdAt"].isoformat() if hasattr(data["createdAt"], "isoformat") else data["createdAt"]
                 }
             }
         }

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -104,6 +104,9 @@ gcloud run deploy webhook-service \
 
 - Cloud RunのサービスはデフォルトでIAM認証が必要です
 - このプロジェクトではIFTTTからのWebhookを受け取るため、`--allow-unauthenticated`フラグを使用しています
+- セキュリティ対策として、WebhookエンドポイントでAPI Key認証を実装しています
+  - リクエストヘッダー`X-API-Key`で認証を行います
+  - API Keyは環境変数`WEBHOOK_API_KEY`で設定します
 - 追加のセキュリティ層として、Webhookエンドポイントで独自の認証トークンを実装することを推奨します
 
 ### 環境変数の設定
@@ -113,7 +116,8 @@ gcloud run deploy webhook-service \
 ```bash
 gcloud run services update webhook-service \
     --set-env-vars="NOTION_API_KEY=your_notion_api_key" \
-    --set-env-vars="WEBHOOK_SECRET=your_webhook_secret"
+    --set-env-vars="NOTION_DATABASE_ID=your_database_id" \
+    --set-env-vars="WEBHOOK_API_KEY=your_webhook_api_key"
 ```
 
 ## 6. 動作確認

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+@pytest.fixture(autouse=True)
+def setup_env():
+    """テスト環境のセットアップ"""
+    # テスト用のAPI Keyを環境変数に設定
+    os.environ["WEBHOOK_API_KEY"] = "test-api-key"
+    yield
+    # テスト後にAPI Keyを削除
+    os.environ.pop("WEBHOOK_API_KEY", None)
+
+@pytest.fixture
+def test_client():
+    """テストクライアントを提供するフィクスチャ"""
+    return TestClient(app)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,28 +8,31 @@ from app.exceptions import ValidationException
 # テスト用の環境変数を読み込む
 load_dotenv(".env.test")
 
-client = TestClient(app)
+@pytest.fixture
+def test_client():
+    return TestClient(app)
 
-def test_root():
+def test_root(test_client):
     """ルートエンドポイントのテスト"""
-    response = client.get("/")
+    response = test_client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Welcome to Save Liked Post in Notion API"}
 
-def test_webhook_get():
+def test_webhook_get(test_client):
     """GETリクエストのテスト"""
-    response = client.get("/webhook")
+    headers = {"X-API-Key": "test-api-key"}
+    response = test_client.get("/webhook", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
 
-def test_webhook_post_with_invalid_date():
+def test_webhook_post_with_invalid_date(test_client):
     """不正な日付フォーマットのテスト"""
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___invalid-date___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
-    response = client.post(
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers={"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
     )
     assert response.status_code == 422
     assert response.json() == {
@@ -37,52 +40,60 @@ def test_webhook_post_with_invalid_date():
         "details": {}
     }
 
-def test_webhook_post_with_empty_text():
+def test_webhook_post_with_empty_text(test_client):
     """空のテキストフィールドのテスト"""
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
-    response = client.post(
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers={"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
     )
     assert response.status_code == 422
+    assert response.json() == {
+        "message": "Text field cannot be empty",
+        "details": {}
+    }
 
-def test_webhook_post_with_missing_field():
+def test_webhook_post_with_missing_field(test_client):
     """必須フィールドが欠けているテスト"""
     # フィールドの順序: text, userName, linkToTweet, createdAt（tweetEmbedCodeが欠けている）
     raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z'''
-    response = client.post(
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers={"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
     )
     assert response.status_code == 422
+    assert response.json() == {
+        "message": "Invalid request format. Expected 5 fields separated by ___POST_FIELD_SEPARATOR___",
+        "details": {"received_fields": 4}
+    }
 
-def test_webhook_post_success(monkeypatch):
+def test_webhook_post_success(test_client, monkeypatch):
     """正常なPOSTリクエストのテスト"""
     # NotionServiceのcreate_pageメソッドをモック
     def mock_create_page(self, data):
         return {"id": "test-page-id"}
-    
+
     # NotionServiceのadd_tweet_embed_codeメソッドをモック
     def mock_add_tweet_embed_code(self, page_id, tweet_embed_code):
         return {"id": page_id}
-    
+
     # モックを適用
     from app.services.notion_service import NotionService
     monkeypatch.setattr(NotionService, "create_page", mock_create_page)
     monkeypatch.setattr(NotionService, "add_tweet_embed_code", mock_add_tweet_embed_code)
-    
+
     from datetime import datetime
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = f'''Test tweet with
 line breaks and "quotes"___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___{datetime.now().isoformat()}___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
 
-    response = client.post(
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers={"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
     )
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,12 +2,19 @@ from fastapi.testclient import TestClient
 import pytest
 from app.main import app
 from app.exceptions import NotionAPIException
+import os
 
 client = TestClient(app)
 
+@pytest.fixture(autouse=True)
+def setup_test_env(monkeypatch):
+    """テスト用の環境変数を設定"""
+    monkeypatch.setenv("WEBHOOK_API_KEY", "test-api-key")
+
 def test_webhook_get():
     """GETリクエストのテスト"""
-    response = client.get("/webhook")
+    headers = {"X-API-Key": "test-api-key"}
+    response = client.get("/webhook", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
 
@@ -33,10 +40,11 @@ tweet with
 line breaks and "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test
 Tweet</blockquote>'''
     
+    headers = {"X-API-Key": "test-api-key"}
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}  # JSONではないのでContent-Typeを変更
+        headers=headers
     )
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}
@@ -46,10 +54,11 @@ def test_webhook_post_missing_field():
     # フィールドの順序: text, userName, linkToTweet, createdAt（tweetEmbedCodeが欠けている）
     raw_body = '''This is a test tweet___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z'''
     
+    headers = {"X-API-Key": "test-api-key"}
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers=headers
     )
     assert response.status_code == 422
 
@@ -59,10 +68,11 @@ def test_webhook_post_invalid_date_format():
     raw_body = '''This is a test
 tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___invalid-date___POST_FIELD_SEPARATOR___<blockquote>Test Tweet</blockquote>'''
     
+    headers = {"X-API-Key": "test-api-key"}
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers=headers
     )
     assert response.status_code == 422
     assert response.json() == {
@@ -87,10 +97,11 @@ def test_webhook_post_with_formatted_date(monkeypatch):
     
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___February 11, 2025 at 01:25AM___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
+    headers = {"X-API-Key": "test-api-key"}
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers=headers
     )
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}
@@ -110,10 +121,11 @@ def test_webhook_post_notion_api_error(monkeypatch):
 tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test
 Tweet</blockquote>'''
     
+    headers = {"X-API-Key": "test-api-key"}
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers=headers
     )
     assert response.status_code == 500
     assert response.json() == {
@@ -132,3 +144,36 @@ def test_webhook_post_empty_text():
         headers={"Content-Type": "text/plain"}
     )
     assert response.status_code == 422
+
+def test_webhook_without_api_key():
+    """API Keyなしのリクエストのテスト"""
+    response = client.get("/webhook")
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {
+            "message": "API key is missing",
+            "details": {}
+        }
+    }
+
+def test_webhook_with_invalid_api_key():
+    """不正なAPI Keyのテスト"""
+    headers = {"X-API-Key": "invalid-key"}
+    response = client.get("/webhook", headers=headers)
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {
+            "message": "Invalid API key",
+            "details": {}
+        }
+    }
+
+def test_webhook_with_valid_api_key(monkeypatch):
+    """有効なAPI Keyのテスト"""
+    # 環境変数のモック
+    monkeypatch.setenv("WEBHOOK_API_KEY", "test-api-key")
+
+    headers = {"X-API-Key": "test-api-key"}
+    response = client.get("/webhook", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -4,21 +4,23 @@ from app.main import app
 from app.exceptions import NotionAPIException
 import os
 
-client = TestClient(app)
+@pytest.fixture
+def test_client():
+    return TestClient(app)
 
 @pytest.fixture(autouse=True)
 def setup_test_env(monkeypatch):
     """テスト用の環境変数を設定"""
     monkeypatch.setenv("WEBHOOK_API_KEY", "test-api-key")
 
-def test_webhook_get():
+def test_webhook_get(test_client):
     """GETリクエストのテスト"""
     headers = {"X-API-Key": "test-api-key"}
-    response = client.get("/webhook", headers=headers)
+    response = test_client.get("/webhook", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
 
-def test_webhook_post_success(monkeypatch):
+def test_webhook_post_success(test_client, monkeypatch):
     """正常なPOSTリクエストのテスト"""
     # NotionServiceのcreate_pageメソッドをモック
     def mock_create_page(self, data):
@@ -40,8 +42,8 @@ tweet with
 line breaks and "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test
 Tweet</blockquote>'''
     
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.post(
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
         headers=headers
@@ -49,27 +51,27 @@ Tweet</blockquote>'''
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}
 
-def test_webhook_post_missing_field():
+def test_webhook_post_missing_field(test_client):
     """必須フィールドが欠けているPOSTリクエストのテスト（フィールド数が足りない）"""
     # フィールドの順序: text, userName, linkToTweet, createdAt（tweetEmbedCodeが欠けている）
     raw_body = '''This is a test tweet___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z'''
     
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.post(
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
         headers=headers
     )
     assert response.status_code == 422
 
-def test_webhook_post_invalid_date_format():
+def test_webhook_post_invalid_date_format(test_client):
     """不正な日付フォーマットのテスト"""
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''This is a test
 tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___invalid-date___POST_FIELD_SEPARATOR___<blockquote>Test Tweet</blockquote>'''
     
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.post(
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
         headers=headers
@@ -80,7 +82,7 @@ tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___h
         "details": {}
     }
 
-def test_webhook_post_with_formatted_date(monkeypatch):
+def test_webhook_post_with_formatted_date(test_client, monkeypatch):
     """Month DD, YYYY at HH:MMAM/PM形式の日付を含むPOSTリクエストのテスト"""
     # NotionServiceのcreate_pageメソッドをモック
     def mock_create_page(self, data):
@@ -97,8 +99,8 @@ def test_webhook_post_with_formatted_date(monkeypatch):
     
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___February 11, 2025 at 01:25AM___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.post(
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
         headers=headers
@@ -106,7 +108,7 @@ def test_webhook_post_with_formatted_date(monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}
 
-def test_webhook_post_notion_api_error(monkeypatch):
+def test_webhook_post_notion_api_error(test_client, monkeypatch):
     """NotionAPIエラーのテスト"""
     # NotionServiceのcreate_pageメソッドをモック（エラーを発生させる）
     def mock_create_page(self, data):
@@ -121,8 +123,8 @@ def test_webhook_post_notion_api_error(monkeypatch):
 tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test
 Tweet</blockquote>'''
     
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.post(
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
         headers=headers
@@ -133,47 +135,40 @@ Tweet</blockquote>'''
         "details": {"error": "Failed to create Notion page"}
     }
 
-def test_webhook_post_empty_text():
+def test_webhook_post_empty_text(test_client):
     """空のテキストフィールドのテスト"""
     # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
     raw_body = '''___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___https://twitter.com/testuser/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test Tweet</blockquote>'''
-    
-    response = client.post(
+
+    headers = {"X-API-Key": "test-api-key", "Content-Type": "text/plain"}
+    response = test_client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "text/plain"}
+        headers=headers
     )
     assert response.status_code == 422
+    assert response.json() == {
+        "message": "Text field cannot be empty",
+        "details": {}
+    }
 
-def test_webhook_without_api_key():
+def test_webhook_without_api_key(test_client):
     """API Keyなしのリクエストのテスト"""
-    response = client.get("/webhook")
+    response = test_client.get("/webhook")
     assert response.status_code == 401
     assert response.json() == {
         "detail": {
-            "message": "API key is missing",
-            "details": {}
+            "message": "Invalid API Key"
         }
     }
 
-def test_webhook_with_invalid_api_key():
+def test_webhook_with_invalid_api_key(test_client):
     """不正なAPI Keyのテスト"""
     headers = {"X-API-Key": "invalid-key"}
-    response = client.get("/webhook", headers=headers)
+    response = test_client.get("/webhook", headers=headers)
     assert response.status_code == 401
     assert response.json() == {
         "detail": {
-            "message": "Invalid API key",
-            "details": {}
+            "message": "Invalid API Key"
         }
     }
-
-def test_webhook_with_valid_api_key(monkeypatch):
-    """有効なAPI Keyのテスト"""
-    # 環境変数のモック
-    monkeypatch.setenv("WEBHOOK_API_KEY", "test-api-key")
-
-    headers = {"X-API-Key": "test-api-key"}
-    response = client.get("/webhook", headers=headers)
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello World"}


### PR DESCRIPTION
## 変更内容

### 機能追加
- FastAPIのDependencyを使用してAPI Key認証を実装
  - ヘッダーで認証を行う
  - API Keyは環境変数で設定

### エラーハンドリング
- エラーレスポンスの形式を統一
  - の形式に統一

### テスト
- API Key認証のテストケースを追加
  - API Keyなしのリクエストのテスト
  - 不正なAPI Keyのテスト
  - 有効なAPI Keyのテスト
- 既存のテストケースにAPI Keyヘッダーを追加

### ドキュメント
- にAPI Key認証の説明を追加
- にWEBHOOK_API_KEY環境変数の設定を追加
- にWEBHOOK_API_KEYを追加