### PR TITLE
fix: normalize line breaks in webhook request body

### DIFF
--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -27,7 +27,16 @@ async def validation_exception_handler(request: Request, exc: ValidationExceptio
 
 async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
     """リクエストバリデーションエラーのハンドラー"""
-    logger.error(f"Request validation error occurred: {exc.errors()}")
+    # リクエストボディを取得
+    body = await request.body()
+    body_str = body.decode() if body else ""
+    
+    logger.error(
+        f"Request validation error occurred: {exc.errors()}, "
+        f"Request details - method: {request.method}, url: {request.url}, "
+        f"headers: {dict(request.headers)}, query_params: {dict(request.query_params)}, "
+        f"raw_body: {body_str}"
+    )
     
     # 日付フォーマットのエラーの場合は、専用のメッセージを返す
     for error in exc.errors():

--- a/app/main.py
+++ b/app/main.py
@@ -54,10 +54,16 @@ async def hello_world():
 
 @app.post("/webhook", response_model=NotionPageResponse)
 async def webhook_post(request: Request):
-    # リクエストボディを取得して改行を正規化
+    # リクエストボディを取得して改行とダブルクォートを正規化
     body = await request.body()
     body_str = body.decode()
-    normalized_body = body_str.replace('\r\n', '\\n').replace('\r', '\\n').replace('\n', '\\n')
+    normalized_body = (
+        body_str
+        .replace('\r\n', '\\n')
+        .replace('\r', '\\n')
+        .replace('\n', '\\n')
+        .replace('"', '\\"')
+    )
     
     try:
         # JSONとしてパース

--- a/app/main.py
+++ b/app/main.py
@@ -96,13 +96,21 @@ async def webhook_post(request: Request):
             
         # 順序に従ってデータを構築
         data = {
-            "text": fields[0],
-            "userName": fields[1],
-            "linkToTweet": fields[2],
-            "createdAt": created_at,
-            "tweetEmbedCode": fields[4]
+            "text": fields[0].strip(),
+            "userName": fields[1].strip(),
+            "linkToTweet": fields[2].strip(),
+            "createdAt": created_at.strip(),
+            "tweetEmbedCode": fields[4].strip()
         }
         
+        # 必須フィールドの空文字チェック
+        required_fields = ["text", "userName", "linkToTweet", "createdAt"]
+        empty_fields = [field for field in required_fields if not data[field]]
+        if empty_fields:
+            error_msg = f"Required fields cannot be empty: {', '.join(empty_fields)}"
+            logging.warning(error_msg)
+            raise ValidationException(error_msg)
+            
         # Tweetモデルとしてバリデーション
         try:
             tweet = Tweet(**data)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, JSONResponse
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, Field, ValidationError
 from datetime import datetime
@@ -79,6 +79,16 @@ async def webhook_post(request: Request):
     except json.JSONDecodeError as e:
         raise ValidationException(f"Invalid JSON format: {str(e)}")
     except ValidationError as e:
+        # バリデーションエラーの詳細を確認
+        for error in e.errors():
+            if error.get("type") == "datetime_from_date_parsing":
+                return JSONResponse(
+                    status_code=422,
+                    content={
+                        "message": "Invalid date format. Expected ISO format.",
+                        "details": {}
+                    }
+                )
         raise ValidationException(f"Invalid Tweet data: {str(e)}")
     except Exception as e:
         raise AppException("Failed to create Notion page", 500, {"error": str(e)})

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, HTTPException, Request, JSONResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, Field, ValidationError
 from datetime import datetime

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.models import Tweet, NotionPageResponse
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.exceptions import ExceptionMiddleware
 import json
+import logging
 
 # 環境変数を読み込む
 load_dotenv()
@@ -67,11 +68,18 @@ async def webhook_post(request: Request):
     body = await request.body()
     body_str = body.decode()
     
+    # デバッグ用ログ
+    logging.info(f"Received webhook request body: {body_str}")
+    
     try:
         # 区切り文字で分割してフィールドを取得
         fields = body_str.split('___POST_FIELD_SEPARATOR___')
+        logging.info(f"Split fields count: {len(fields)}")
+        
         if len(fields) != 5:
-            raise ValidationException("Invalid number of fields in request body")
+            error_msg = f"Invalid number of fields in request body: expected 5, got {len(fields)}"
+            logging.warning(error_msg)
+            raise ValidationException(error_msg)
             
         # 順序に従ってデータを構築
         data = {

--- a/app/main.py
+++ b/app/main.py
@@ -130,9 +130,9 @@ async def webhook_post(request: Request):
         # Notionページの作成
         page = notion_service.create_page({
             "text": tweet.text,
-            "user_name": tweet.userName,
-            "link_to_tweet": tweet.linkToTweet,
-            "created_at": tweet.createdAt.isoformat(),
+            "userName": tweet.userName,
+            "linkToTweet": tweet.linkToTweet,
+            "createdAt": tweet.createdAt.isoformat(),
         })
 
         # ツイートの埋め込みコードを追加

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -43,10 +43,10 @@ class NotionService:
         logger.info("Creating new Notion page", extra={"data": data})
         
         required_fields = ["userName", "text", "linkToTweet", "createdAt"]
-        missing_fields = [field for field in required_fields if field not in data]
+        missing_fields = [field for field in required_fields if not data.get(field)]
         
         if missing_fields:
-            error_msg = f"Required fields are missing: {', '.join(missing_fields)}"
+            error_msg = f"Required fields are missing or empty: {', '.join(missing_fields)}"
             logger.error(error_msg, extra={"data": data})
             raise ValidationException(error_msg, {"missing_fields": missing_fields})
             

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,17 +24,12 @@ def test_webhook_get():
 
 def test_webhook_post_with_invalid_date():
     """不正な日付フォーマットのテスト"""
-    raw_body = '''{
-    "text": "Test tweet",
-    "userName": "test_user",
-    "linkToTweet": "https://twitter.com/test_user/status/123456789",
-    "createdAt": "invalid-date",
-    "tweetEmbedCode": "<blockquote>Test</blockquote>"
-}'''
+    # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
+    raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___invalid-date___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "application/json"}
+        headers={"Content-Type": "text/plain"}
     )
     assert response.status_code == 422
     assert response.json() == {
@@ -44,32 +39,23 @@ def test_webhook_post_with_invalid_date():
 
 def test_webhook_post_with_empty_text():
     """空のテキストフィールドのテスト"""
-    raw_body = '''{
-    "text": "",
-    "userName": "test_user",
-    "linkToTweet": "https://twitter.com/test_user/status/123456789",
-    "createdAt": "2025-02-10T13:35:49Z",
-    "tweetEmbedCode": "<blockquote>Test</blockquote>"
-}'''
+    # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
+    raw_body = '''___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "application/json"}
+        headers={"Content-Type": "text/plain"}
     )
     assert response.status_code == 422
 
 def test_webhook_post_with_missing_field():
     """必須フィールドが欠けているテスト"""
-    raw_body = '''{
-    "text": "Test tweet",
-    "linkToTweet": "https://twitter.com/test_user/status/123456789",
-    "createdAt": "2025-02-10T13:35:49Z",
-    "tweetEmbedCode": "<blockquote>Test</blockquote>"
-}'''
+    # フィールドの順序: text, userName, linkToTweet, createdAt（tweetEmbedCodeが欠けている）
+    raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___2025-02-10T13:35:49Z'''
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "application/json"}
+        headers={"Content-Type": "text/plain"}
     )
     assert response.status_code == 422
 
@@ -89,19 +75,14 @@ def test_webhook_post_success(monkeypatch):
     monkeypatch.setattr(NotionService, "add_tweet_embed_code", mock_add_tweet_embed_code)
     
     from datetime import datetime
-    raw_body = f'''{{
-    "text": "Test tweet with
-line breaks and "quotes"",
-    "userName": "test_user",
-    "linkToTweet": "https://twitter.com/test_user/status/123456789",
-    "createdAt": "{datetime.now().isoformat()}",
-    "tweetEmbedCode": "<blockquote>Test</blockquote>"
-}}'''
+    # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
+    raw_body = f'''Test tweet with
+line breaks and "quotes"___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___{datetime.now().isoformat()}___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
 
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
-        headers={"Content-Type": "application/json"}
+        headers={"Content-Type": "text/plain"}
     )
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -26,39 +26,61 @@ def test_webhook_post_success(monkeypatch):
     monkeypatch.setattr(NotionService, "create_page", mock_create_page)
     monkeypatch.setattr(NotionService, "add_tweet_embed_code", mock_add_tweet_embed_code)
     
-    tweet_data = {
-        "text": "This is a test tweet",
-        "userName": "testuser",
-        "linkToTweet": "https://twitter.com/testuser/status/123456789",
-        "createdAt": "2025-02-10T13:35:49Z",
-        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-    }
-    response = client.post("/webhook", json=tweet_data)
+    # 実際のリクエストボディを模擬
+    raw_body = '''
+{
+    "text": "This is a test
+tweet with
+line breaks and "quotes"",
+    "userName": "testuser",
+    "linkToTweet": "https://twitter.com/testuser/status/123456789",
+    "createdAt": "2025-02-10T13:35:49Z",
+    "tweetEmbedCode": "<blockquote>Test
+Tweet</blockquote>"
+}
+'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == 200
     assert response.json() == {"id": "test-page-id"}
 
 def test_webhook_post_missing_field():
     """必須フィールドが欠けているPOSTリクエストのテスト"""
-    invalid_data = {
-        "text": "Test tweet",
-        "userName": "test_user",
-        # linkToTweetが欠けている
-        "createdAt": "2025-02-10T13:35:49Z",
-        "tweetEmbedCode": "<blockquote>Test</blockquote>"
-    }
-    response = client.post("/webhook", json=invalid_data)
+    raw_body = '''
+{
+    "text": "This is a test tweet",
+    "userName": "testuser",
+    "createdAt": "2025-02-10T13:35:49Z",
+    "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+}
+'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == 422
 
 def test_webhook_post_invalid_date_format():
     """不正な日付フォーマットのテスト"""
-    tweet_data = {
-        "text": "This is a test tweet",
-        "userName": "testuser",
-        "linkToTweet": "https://twitter.com/testuser/status/123456789",
-        "createdAt": "invalid-date",  # Invalid date format
-        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-    }
-    response = client.post("/webhook", json=tweet_data)
+    raw_body = '''
+{
+    "text": "This is a test
+tweet with "quotes"",
+    "userName": "testuser",
+    "linkToTweet": "https://twitter.com/testuser/status/123456789",
+    "createdAt": "invalid-date",
+    "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+}
+'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == 422
     assert response.json() == {
         "message": "Invalid date format. Expected ISO format.",
@@ -70,19 +92,27 @@ def test_webhook_post_notion_api_error(monkeypatch):
     # NotionServiceのcreate_pageメソッドをモック（エラーを発生させる）
     def mock_create_page(self, data):
         raise NotionAPIException("Failed to create Notion page", details={"error": "Failed to create Notion page"})
-    
+
     # モックを適用
     from app.services.notion_service import NotionService
     monkeypatch.setattr(NotionService, "create_page", mock_create_page)
-    
-    tweet_data = {
-        "text": "This is a test tweet",
-        "userName": "testuser",
-        "linkToTweet": "https://twitter.com/testuser/status/123456789",
-        "createdAt": "2025-02-10T13:35:49Z",
-        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-    }
-    response = client.post("/webhook", json=tweet_data)
+
+    raw_body = '''
+{
+    "text": "This is a test
+tweet with "quotes"",
+    "userName": "testuser",
+    "linkToTweet": "https://twitter.com/testuser/status/123456789",
+    "createdAt": "2025-02-10T13:35:49Z",
+    "tweetEmbedCode": "<blockquote>Test
+Tweet</blockquote>"
+}
+'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == 500
     assert response.json() == {
         "message": "Failed to create Notion page",
@@ -91,12 +121,18 @@ def test_webhook_post_notion_api_error(monkeypatch):
 
 def test_webhook_post_empty_text():
     """空のテキストフィールドのテスト"""
-    tweet_data = {
-        "text": "",  # 空のテキスト
-        "userName": "testuser",
-        "linkToTweet": "https://twitter.com/testuser/status/123456789",
-        "createdAt": "2025-02-10T13:35:49Z",
-        "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-    }
-    response = client.post("/webhook", json=tweet_data)
+    raw_body = '''
+{
+    "text": "",
+    "userName": "testuser",
+    "linkToTweet": "https://twitter.com/testuser/status/123456789",
+    "createdAt": "2025-02-10T13:35:49Z",
+    "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
+}
+'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == 422

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -70,6 +70,17 @@ tweet with "quotes"___POST_FIELD_SEPARATOR___testuser___POST_FIELD_SEPARATOR___h
         "details": {}
     }
 
+def test_webhook_post_with_formatted_date():
+    """Month DD, YYYY at HH:MMAM/PM形式の日付を含むPOSTリクエストのテスト"""
+    # フィールドの順序: text, userName, linkToTweet, createdAt, tweetEmbedCode
+    raw_body = '''Test tweet___POST_FIELD_SEPARATOR___test_user___POST_FIELD_SEPARATOR___https://twitter.com/test_user/status/123456789___POST_FIELD_SEPARATOR___February 11, 2025 at 01:25AM___POST_FIELD_SEPARATOR___<blockquote>Test</blockquote>'''
+    response = client.post(
+        "/webhook",
+        content=raw_body.encode(),
+        headers={"Content-Type": "text/plain"}
+    )
+    assert response.status_code == 200
+
 def test_webhook_post_notion_api_error(monkeypatch):
     """NotionAPIエラーのテスト"""
     # NotionServiceのcreate_pageメソッドをモック（エラーを発生させる）

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -26,9 +26,8 @@ def test_webhook_post_success(monkeypatch):
     monkeypatch.setattr(NotionService, "create_page", mock_create_page)
     monkeypatch.setattr(NotionService, "add_tweet_embed_code", mock_add_tweet_embed_code)
     
-    # 実際のリクエストボディを模擬
-    raw_body = '''
-{
+    # 実際のリクエストボディを模擬（改行とダブルクォートを生の状態で含む）
+    raw_body = '''{
     "text": "This is a test
 tweet with
 line breaks and "quotes"",
@@ -37,8 +36,8 @@ line breaks and "quotes"",
     "createdAt": "2025-02-10T13:35:49Z",
     "tweetEmbedCode": "<blockquote>Test
 Tweet</blockquote>"
-}
-'''
+}'''
+    
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
@@ -49,14 +48,13 @@ Tweet</blockquote>"
 
 def test_webhook_post_missing_field():
     """必須フィールドが欠けているPOSTリクエストのテスト"""
-    raw_body = '''
-{
+    raw_body = '''{
     "text": "This is a test tweet",
     "userName": "testuser",
     "createdAt": "2025-02-10T13:35:49Z",
     "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-}
-'''
+}'''
+    
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
@@ -66,16 +64,15 @@ def test_webhook_post_missing_field():
 
 def test_webhook_post_invalid_date_format():
     """不正な日付フォーマットのテスト"""
-    raw_body = '''
-{
+    raw_body = '''{
     "text": "This is a test
 tweet with "quotes"",
     "userName": "testuser",
     "linkToTweet": "https://twitter.com/testuser/status/123456789",
     "createdAt": "invalid-date",
     "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-}
-'''
+}'''
+    
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
@@ -97,8 +94,7 @@ def test_webhook_post_notion_api_error(monkeypatch):
     from app.services.notion_service import NotionService
     monkeypatch.setattr(NotionService, "create_page", mock_create_page)
 
-    raw_body = '''
-{
+    raw_body = '''{
     "text": "This is a test
 tweet with "quotes"",
     "userName": "testuser",
@@ -106,8 +102,8 @@ tweet with "quotes"",
     "createdAt": "2025-02-10T13:35:49Z",
     "tweetEmbedCode": "<blockquote>Test
 Tweet</blockquote>"
-}
-'''
+}'''
+    
     response = client.post(
         "/webhook",
         content=raw_body.encode(),
@@ -121,15 +117,14 @@ Tweet</blockquote>"
 
 def test_webhook_post_empty_text():
     """空のテキストフィールドのテスト"""
-    raw_body = '''
-{
+    raw_body = '''{
     "text": "",
     "userName": "testuser",
     "linkToTweet": "https://twitter.com/testuser/status/123456789",
     "createdAt": "2025-02-10T13:35:49Z",
     "tweetEmbedCode": "<blockquote>Test Tweet</blockquote>"
-}
-'''
+}'''
+    
     response = client.post(
         "/webhook",
         content=raw_body.encode(),


### PR DESCRIPTION
## 変更内容
- webhookエンドポイントでリクエストボディを受け取る際に、改行文字を正規化してからJSONパースを行うように修正
- JSONパースエラーとバリデーションエラーを個別に処理するように改善

## 背景
- webhookリクエストのボディに改行文字が含まれており、JSONパースに失敗する問題があった
- 改行文字を適切にエスケープすることで、JSONパースが成功するように対応